### PR TITLE
Adding code snippet to add a custom close button

### DIFF
--- a/CustomOnCloseButton/Readme.md
+++ b/CustomOnCloseButton/Readme.md
@@ -1,0 +1,15 @@
+
+# Custom On Close Button (with bonus close on loss on click backdrop)
+
+This snippet will help you create a custom close button so you don't have to stick with the defined button on the guides. Also, when you click off of the guide - it will also dismiss. A nice feature add that corresponds with most dialog behavior you find right now.
+
+# Pre-Requisite
+* A publicly available image accessible via URL for the close button.
+
+### To Use This Script
+
+* Create a new guide
+* On your guide, create a new HTML Code Block
+* Copy and paste this code into the *Javascript* tab.
+* Replace *<URL_TO_YOUR_CLOSE_BUTTON_IMAGE>* with the URL to your close button image
+

--- a/CustomOnCloseButton/customOnCloseButton.js
+++ b/CustomOnCloseButton/customOnCloseButton.js
@@ -1,0 +1,39 @@
+/*
+ *  Creates a custom close button based on an image.
+ */
+(function _overrideCloseBehavior(imageURL, guide){
+ 
+    /* Create the custom button element */
+    let closeBtn = document.createElement('IMG');
+    closeBtn.id = '_pinptCloseBtn';
+    closeBtn.src = imageURL;
+
+    /* Style the button */
+    closeBtn.style.float = 'none';
+    closeBtn.style.position = 'absolute'; 
+    closeBtn.style.top = '0px';
+    closeBtn.style.right = '0px';
+    closeBtn.style.height = 'auto';
+    closeBtn.style.width = '75px';       // <-- REPLACE WITH YOUR IMAGE WIDTH
+    
+    /* Set button onClick to pendo function to dismiss active guide */
+    closeBtn.onclick = pendo.onGuideDismissed; 
+  
+    /* Check to see if the user clicks on the backdrop */
+    document.addEventListener('click', function(evt) { 
+		let elem = evt.target || evt.srcElement;
+        
+        // If the user clicked on the pendo backdrop dismiss it.
+        if(elem.id === 'pendo-backdrop') {
+            pendo.onGuideDismissed();
+        }
+     
+    }, false);
+
+    /* Insert the new close button into the DOM of the guide */
+    guide.appendChild(closeBtn);
+    
+})( 
+    '<URL_TO_YOUR_CLOSE_BUTTON_IMAGE>',
+    document.getElementById('pendo-guide-container')
+);


### PR DESCRIPTION
We're using this code snippet to override the default close button with a custom image. Additionally we wanted behavior in the guide to dismiss when the user clicks somewhere other than the guide.