### PR TITLE
added logic to be able to dismiss RC with click on badge again

### DIFF
--- a/resourceCenter/dismissRCWhenClickOutsideBadgeRC/dismissRCWhenClickOutsideBadgeRC.js
+++ b/resourceCenter/dismissRCWhenClickOutsideBadgeRC/dismissRCWhenClickOutsideBadgeRC.js
@@ -19,6 +19,8 @@ End result: The 2.0 Pendo Resource Center will hide itself when a click is regis
                 if (!dom(tgt).closest('#pendo-resource-center-container').length) {
                     pendo.BuildingBlocks.BuildingBlockResourceCenter.dismissResourceCenter();
                     pendo.pro.rcHidden = true;
+                } else if (tgt.classList.contains("_pendo-resource-center-close-button")) {
+                    pendo.pro.rcHidden = true;
                 }
             }
             pendo.attachEvent(document, 'click', pendo.pro.hideRC);

--- a/resourceCenter/dismissRCWhenClickOutsideBadgeRC/dismissRCWhenClickOutsideBadgeRC.js
+++ b/resourceCenter/dismissRCWhenClickOutsideBadgeRC/dismissRCWhenClickOutsideBadgeRC.js
@@ -13,7 +13,7 @@ End result: The 2.0 Pendo Resource Center will hide itself when a click is regis
             }
         }
 
-	    if(!pendo.pro.hideRC) {
+        if (!pendo.pro.hideRC) {
             pendo.pro.hideRC = function(e) {
                 const tgt = e.target || e.srcElement;
                 if (!dom(tgt).closest('#pendo-resource-center-container').length) {
@@ -28,8 +28,8 @@ End result: The 2.0 Pendo Resource Center will hide itself when a click is regis
 
         pendo.onGuideDismissed(guide.steps[guide.getPositionOfStep(step) - 1]);
 
-        if(pendo.pro.rcHidden) {
-	        pendo.BuildingBlocks.BuildingBlockResourceCenter.getResourceCenter().show();
+        if (pendo.pro.rcHidden) {
+            pendo.BuildingBlocks.BuildingBlockResourceCenter.getResourceCenter().show();
             pendo.pro.rcHidden = false;
         } else {
             pendo.BuildingBlocks.BuildingBlockResourceCenter.dismissResourceCenter();

--- a/resourceCenter/dismissRCWhenClickOutsideBadgeRC/dismissRCWhenClickOutsideBadgeRC.js
+++ b/resourceCenter/dismissRCWhenClickOutsideBadgeRC/dismissRCWhenClickOutsideBadgeRC.js
@@ -8,19 +8,30 @@ End result: The 2.0 Pendo Resource Center will hide itself when a click is regis
 (function offclickRC(dom) {
     if (!pendo.designerEnabled) {
         if (!pendo.pro) {
-            pendo.pro = {}
+            pendo.pro = {
+                rcHidden: true,
+            }
         }
-        //window.alert("The Resource Center badge was hovered over.");
+
 	    if(!pendo.pro.hideRC) {
             pendo.pro.hideRC = function(e) {
-                var tgt = e.target || e.srcElement;
+                const tgt = e.target || e.srcElement;
                 if (!dom(tgt).closest('#pendo-resource-center-container').length) {
                     pendo.BuildingBlocks.BuildingBlockResourceCenter.dismissResourceCenter();
+                    pendo.pro.rcHidden = true;
                 }
             }
             pendo.attachEvent(document, 'click', pendo.pro.hideRC);
         }
+
         pendo.onGuideDismissed(guide.steps[guide.getPositionOfStep(step) - 1]);
-        pendo.BuildingBlocks.BuildingBlockResourceCenter.getResourceCenter().show();
+
+        if(pendo.pro.rcHidden) {
+	        pendo.BuildingBlocks.BuildingBlockResourceCenter.getResourceCenter().show();
+            pendo.pro.rcHidden = false;
+        } else {
+            pendo.BuildingBlocks.BuildingBlockResourceCenter.dismissResourceCenter();
+            pendo.pro.rcHidden = true;
+        }
     }
 })(pendo.dom);


### PR DESCRIPTION
Added some logic to dismiss RC by clicking on the badge. The old implementation broke this behaviour.